### PR TITLE
Show4D: add vmin/vmax for absolute intensity range

### DIFF
--- a/js/show4d/index.tsx
+++ b/js/show4d/index.tsx
@@ -686,6 +686,10 @@ function Show4D() {
   const [fftWindow, setFftWindow] = useModelState<boolean>("fft_window");
   const [disabledTools, setDisabledTools] = useModelState<string[]>("disabled_tools");
   const [hiddenTools, setHiddenTools] = useModelState<string[]>("hidden_tools");
+  const [traitNavVmin] = useModelState<number | null>("nav_vmin");
+  const [traitNavVmax] = useModelState<number | null>("nav_vmax");
+  const [traitSigVmin] = useModelState<number | null>("sig_vmin");
+  const [traitSigVmax] = useModelState<number | null>("sig_vmax");
 
   const toolVisibility = React.useMemo(
     () => computeToolVisibility("Show4D", disabledTools, hiddenTools),
@@ -998,7 +1002,22 @@ function Show4D() {
     }
 
     const { min: dataMin, max: dataMax } = findDataRange(scaled);
-    const { vmin, vmax } = sliderRange(dataMin, dataMax, navVminPct, navVmaxPct);
+    const hasNavAbsRange = traitNavVmin != null && traitNavVmax != null;
+    let vmin: number, vmax: number;
+    if (hasNavAbsRange) {
+      if (navScaleMode === "log") {
+        vmin = Math.log1p(Math.max(traitNavVmin!, 0));
+        vmax = Math.log1p(Math.max(traitNavVmax!, 0));
+      } else if (navScaleMode === "power") {
+        vmin = Math.pow(Math.max(traitNavVmin!, 0), navPowerExp);
+        vmax = Math.pow(Math.max(traitNavVmax!, 0), navPowerExp);
+      } else {
+        vmin = traitNavVmin!;
+        vmax = traitNavVmax!;
+      }
+    } else {
+      ({ vmin, vmax } = sliderRange(dataMin, dataMax, navVminPct, navVmaxPct));
+    }
 
     const width = navCols;
     const height = navRows;
@@ -1025,7 +1044,7 @@ function Show4D() {
     applyColormap(scaled, imgData.data, lut, vmin, vmax);
     offCtx.putImageData(imgData, 0, 0);
     setNavOffscreenVersion(v => v + 1);
-  }, [navImageBytes, navColormap, navVminPct, navVmaxPct, navScaleMode, navPowerExp, navRows, navCols]);
+  }, [navImageBytes, navColormap, navVminPct, navVmaxPct, navScaleMode, navPowerExp, navRows, navCols, traitNavVmin, traitNavVmax]);
 
   // ── Nav zoom/pan redraw (lightweight — just drawImage with transform) ──
   // useLayoutEffect prevents black flash when canvas dimensions change (resize)
@@ -1060,7 +1079,22 @@ function Show4D() {
     }
 
     const { min: dataMin, max: dataMax } = findDataRange(scaled);
-    const { vmin, vmax } = sliderRange(dataMin, dataMax, sigVminPct, sigVmaxPct);
+    const hasSigAbsRange = traitSigVmin != null && traitSigVmax != null;
+    let vmin: number, vmax: number;
+    if (hasSigAbsRange) {
+      if (sigScaleMode === "log") {
+        vmin = Math.log1p(Math.max(traitSigVmin!, 0));
+        vmax = Math.log1p(Math.max(traitSigVmax!, 0));
+      } else if (sigScaleMode === "power") {
+        vmin = Math.pow(Math.max(traitSigVmin!, 0), sigPowerExp);
+        vmax = Math.pow(Math.max(traitSigVmax!, 0), sigPowerExp);
+      } else {
+        vmin = traitSigVmin!;
+        vmax = traitSigVmax!;
+      }
+    } else {
+      ({ vmin, vmax } = sliderRange(dataMin, dataMax, sigVminPct, sigVmaxPct));
+    }
 
     const width = sigCols;
     const height = sigRows;
@@ -1087,7 +1121,7 @@ function Show4D() {
     applyColormap(scaled, imgData.data, lut, vmin, vmax);
     offCtx.putImageData(imgData, 0, 0);
     setSigOffscreenVersion(v => v + 1);
-  }, [frameBytes, sigColormap, sigVminPct, sigVmaxPct, sigScaleMode, sigPowerExp, sigRows, sigCols]);
+  }, [frameBytes, sigColormap, sigVminPct, sigVmaxPct, sigScaleMode, sigPowerExp, sigRows, sigCols, traitSigVmin, traitSigVmax]);
 
   // ── Signal zoom/pan redraw (lightweight — just drawImage with transform) ──
   React.useLayoutEffect(() => {
@@ -2008,15 +2042,23 @@ function Show4D() {
     const navData = new Float32Array(navImageBytes.buffer, navImageBytes.byteOffset, navImageBytes.byteLength / 4);
     const lut = COLORMAPS[navColormap] || COLORMAPS.inferno;
     const { min: dMin, max: dMax } = findDataRange(navData);
-    const offscreen = renderToOffscreen(navData, navCols, navRows, lut, dMin, dMax);
+    let eVmin: number, eVmax: number;
+    if (traitNavVmin != null && traitNavVmax != null) {
+      eVmin = traitNavVmin;
+      eVmax = traitNavVmax;
+    } else {
+      eVmin = dMin;
+      eVmax = dMax;
+    }
+    const offscreen = renderToOffscreen(navData, navCols, navRows, lut, eVmin, eVmax);
     if (!offscreen) return;
     const pixelSizeAngstrom = navPixelSize > 0 && navPixelUnit === "\u00C5" ? navPixelSize : navPixelSize > 0 && navPixelUnit === "nm" ? navPixelSize * 10 : 0;
     const figCanvas = exportFigure({
       imageCanvas: offscreen,
       title: title || "Navigation",
       lut,
-      vmin: dMin,
-      vmax: dMax,
+      vmin: eVmin,
+      vmax: eVmax,
       pixelSize: pixelSizeAngstrom > 0 ? pixelSizeAngstrom : undefined,
       showColorbar: withColorbar,
       showScaleBar: pixelSizeAngstrom > 0,
@@ -2049,7 +2091,21 @@ function Show4D() {
     }
     const lut = COLORMAPS[sigColormap] || COLORMAPS.inferno;
     const { min: pMin, max: pMax } = findDataRange(processed);
-    const { vmin, vmax } = sliderRange(pMin, pMax, sigVminPct, sigVmaxPct);
+    let vmin: number, vmax: number;
+    if (traitSigVmin != null && traitSigVmax != null) {
+      if (sigScaleMode === "log") {
+        vmin = Math.log1p(Math.max(traitSigVmin, 0));
+        vmax = Math.log1p(Math.max(traitSigVmax, 0));
+      } else if (sigScaleMode === "power") {
+        vmin = Math.pow(Math.max(traitSigVmin, 0), sigPowerExp);
+        vmax = Math.pow(Math.max(traitSigVmax, 0), sigPowerExp);
+      } else {
+        vmin = traitSigVmin;
+        vmax = traitSigVmax;
+      }
+    } else {
+      ({ vmin, vmax } = sliderRange(pMin, pMax, sigVminPct, sigVmaxPct));
+    }
     const offscreen = renderToOffscreen(processed, sigCols, sigRows, lut, vmin, vmax);
     if (!offscreen) return;
     const pixelSizeAngstrom = sigPixelSize > 0 && sigPixelUnit === "\u00C5" ? sigPixelSize : sigPixelSize > 0 && sigPixelUnit === "nm" ? sigPixelSize * 10 : 0;

--- a/src/quantem/widget/show4d.py
+++ b/src/quantem/widget/show4d.py
@@ -76,6 +76,18 @@ class Show4D(anywidget.AnyWidget):
         Low percentile for auto-contrast clipping.
     percentile_high : float, default 99.5
         High percentile for auto-contrast clipping.
+    nav_vmin : float, optional
+        Absolute minimum intensity for navigation panel color mapping.
+        When both nav_vmin and nav_vmax are set, overrides auto-contrast
+        and slider percentiles for the navigation panel.
+    nav_vmax : float, optional
+        Absolute maximum intensity for navigation panel color mapping.
+    sig_vmin : float, optional
+        Absolute minimum intensity for signal panel color mapping.
+        When both sig_vmin and sig_vmax are set, overrides auto-contrast
+        and slider percentiles for the signal panel.
+    sig_vmax : float, optional
+        Absolute maximum intensity for signal panel color mapping.
     disabled_tools : list of str, optional
         Tool groups to lock while still showing controls. Supported:
         ``"display"``, ``"roi"``, ``"histogram"``, ``"profile"``,
@@ -141,6 +153,11 @@ class Show4D(anywidget.AnyWidget):
     hidden_tools = traitlets.List(traitlets.Unicode()).tag(sync=True)
     percentile_low = traitlets.Float(0.5).tag(sync=True)
     percentile_high = traitlets.Float(99.5).tag(sync=True)
+    # Absolute intensity bounds (per panel)
+    nav_vmin = traitlets.Float(None, allow_none=True).tag(sync=True)
+    nav_vmax = traitlets.Float(None, allow_none=True).tag(sync=True)
+    sig_vmin = traitlets.Float(None, allow_none=True).tag(sync=True)
+    sig_vmax = traitlets.Float(None, allow_none=True).tag(sync=True)
     # Scale bars
     nav_pixel_size = traitlets.Float(0.0).tag(sync=True)
     sig_pixel_size = traitlets.Float(0.0).tag(sync=True)
@@ -268,6 +285,10 @@ class Show4D(anywidget.AnyWidget):
         sig_pixel_unit="px",
         percentile_low=0.5,
         percentile_high=99.5,
+        nav_vmin=None,
+        nav_vmax=None,
+        sig_vmin=None,
+        sig_vmax=None,
         snap_enabled=False,
         snap_radius=5,
         disabled_tools=None,
@@ -353,6 +374,10 @@ class Show4D(anywidget.AnyWidget):
         self.fft_window = fft_window
         self.percentile_low = percentile_low
         self.percentile_high = percentile_high
+        self.nav_vmin = nav_vmin
+        self.nav_vmax = nav_vmax
+        self.sig_vmin = sig_vmin
+        self.sig_vmax = sig_vmax
         self.snap_enabled = snap_enabled
         self.snap_radius = snap_radius
         self.disabled_tools = self._build_disabled_tools(
@@ -554,6 +579,10 @@ class Show4D(anywidget.AnyWidget):
             "hidden_tools": self.hidden_tools,
             "percentile_low": self.percentile_low,
             "percentile_high": self.percentile_high,
+            "nav_vmin": self.nav_vmin,
+            "nav_vmax": self.nav_vmax,
+            "sig_vmin": self.sig_vmin,
+            "sig_vmax": self.sig_vmax,
             "nav_pixel_size": self.nav_pixel_size,
             "sig_pixel_size": self.sig_pixel_size,
             "nav_pixel_unit": self.nav_pixel_unit,
@@ -593,7 +622,14 @@ class Show4D(anywidget.AnyWidget):
         lines.append(f"Position: ({self.pos_row}, {self.pos_col})")
         cmap = self.cmap
         scale = "log" if self.log_scale else "linear"
-        contrast = "auto contrast" if self.auto_contrast else "manual contrast"
+        if self.sig_vmin is not None and self.sig_vmax is not None:
+            contrast = f"sig_vmin={self.sig_vmin:.4g}, sig_vmax={self.sig_vmax:.4g}"
+        elif self.auto_contrast:
+            contrast = "auto contrast"
+        else:
+            contrast = "manual contrast"
+        if self.nav_vmin is not None and self.nav_vmax is not None:
+            contrast += f" | nav_vmin={self.nav_vmin:.4g}, nav_vmax={self.nav_vmax:.4g}"
         display = f"{cmap} | {contrast} | {scale}"
         if self.show_fft:
             display += " | FFT"
@@ -755,10 +791,18 @@ class Show4D(anywidget.AnyWidget):
     def _normalize_frame(self, frame: np.ndarray) -> np.ndarray:
         if self.log_scale:
             frame = np.log1p(np.maximum(frame, 0))
-        fmin, fmax = float(frame.min()), float(frame.max())
-        if self.auto_contrast:
+        if self.sig_vmin is not None and self.sig_vmax is not None:
+            fmin = float(self.sig_vmin)
+            fmax = float(self.sig_vmax)
+            if self.log_scale:
+                fmin = float(np.log1p(max(fmin, 0)))
+                fmax = float(np.log1p(max(fmax, 0)))
+        elif self.auto_contrast:
             fmin = float(np.percentile(frame, self.percentile_low))
             fmax = float(np.percentile(frame, self.percentile_high))
+        else:
+            fmin = float(frame.min())
+            fmax = float(frame.max())
         if fmax > fmin:
             return np.clip((frame - fmin) / (fmax - fmin) * 255, 0, 255).astype(np.uint8)
         return np.zeros(frame.shape, dtype=np.uint8)
@@ -890,7 +934,11 @@ class Show4D(anywidget.AnyWidget):
             normalized = self._normalize_frame(frame)
         else:
             frame = self._nav_image
-            nav_min, nav_max = float(frame.min()), float(frame.max())
+            if self.nav_vmin is not None and self.nav_vmax is not None:
+                nav_min = float(self.nav_vmin)
+                nav_max = float(self.nav_vmax)
+            else:
+                nav_min, nav_max = float(frame.min()), float(frame.max())
             if nav_max > nav_min:
                 normalized = np.clip(
                     (frame - nav_min) / (nav_max - nav_min) * 255, 0, 255

--- a/tests/test_widget_show4d.py
+++ b/tests/test_widget_show4d.py
@@ -536,3 +536,80 @@ def test_show4d_show_controls_default():
     data = np.random.rand(4, 4, 8, 8).astype(np.float32)
     w = Show4D(data)
     assert w.show_controls is True
+
+
+# ── vmin/vmax tests ──────────────────────────────────────────────────────────
+
+
+def test_show4d_vmin_vmax_default_none():
+    data = np.random.rand(4, 4, 8, 8).astype(np.float32)
+    w = Show4D(data)
+    assert w.nav_vmin is None
+    assert w.nav_vmax is None
+    assert w.sig_vmin is None
+    assert w.sig_vmax is None
+
+
+def test_show4d_vmin_vmax_constructor():
+    data = np.random.rand(4, 4, 8, 8).astype(np.float32) * 1000
+    w = Show4D(data, nav_vmin=10, nav_vmax=500, sig_vmin=0, sig_vmax=800)
+    assert w.nav_vmin == pytest.approx(10)
+    assert w.nav_vmax == pytest.approx(500)
+    assert w.sig_vmin == pytest.approx(0)
+    assert w.sig_vmax == pytest.approx(800)
+
+
+def test_show4d_vmin_vmax_state_dict_roundtrip():
+    data = np.random.rand(4, 4, 8, 8).astype(np.float32) * 1000
+    w = Show4D(data, nav_vmin=10, nav_vmax=500, sig_vmin=0, sig_vmax=800)
+    sd = w.state_dict()
+    assert sd["nav_vmin"] == pytest.approx(10)
+    assert sd["nav_vmax"] == pytest.approx(500)
+    assert sd["sig_vmin"] == pytest.approx(0)
+    assert sd["sig_vmax"] == pytest.approx(800)
+    w2 = Show4D(data, state=sd)
+    assert w2.nav_vmin == pytest.approx(10)
+    assert w2.nav_vmax == pytest.approx(500)
+    assert w2.sig_vmin == pytest.approx(0)
+    assert w2.sig_vmax == pytest.approx(800)
+
+
+def test_show4d_vmin_vmax_none_in_state_dict():
+    data = np.random.rand(4, 4, 8, 8).astype(np.float32)
+    w = Show4D(data)
+    sd = w.state_dict()
+    assert sd["nav_vmin"] is None
+    assert sd["nav_vmax"] is None
+    assert sd["sig_vmin"] is None
+    assert sd["sig_vmax"] is None
+
+
+def test_show4d_vmin_vmax_normalize_frame():
+    data = np.zeros((2, 2, 2, 2), dtype=np.float32)
+    frame = np.array([[0, 500], [1000, 1500]], dtype=np.float32)
+    w = Show4D(data, sig_vmin=0, sig_vmax=1000)
+    result = w._normalize_frame(frame)
+    assert result[0, 0] == 0
+    assert result[1, 0] == 255
+    assert result[1, 1] == 255  # clamped
+    assert 120 <= result[0, 1] <= 135  # ~127
+
+
+def test_show4d_vmin_vmax_normalize_frame_log():
+    data = np.zeros((2, 2, 2, 2), dtype=np.float32)
+    frame = np.array([[0, 100], [1000, 10000]], dtype=np.float32)
+    w = Show4D(data, sig_vmin=0, sig_vmax=10000, log_scale=True)
+    result = w._normalize_frame(frame)
+    assert result[0, 0] == 0
+    assert result[1, 1] == 255
+
+
+def test_show4d_vmin_vmax_summary(capsys):
+    data = np.random.rand(4, 4, 8, 8).astype(np.float32)
+    w = Show4D(data, sig_vmin=0, sig_vmax=1000, nav_vmin=10, nav_vmax=500)
+    w.summary()
+    out = capsys.readouterr().out
+    assert "sig_vmin=0" in out
+    assert "sig_vmax=1000" in out
+    assert "nav_vmin=10" in out
+    assert "nav_vmax=500" in out


### PR DESCRIPTION
Address #81, we do the following:
- Adds nav_vmin/nav_vmax and sig_vmin/sig_vmax traits to Show4D; when both set, overrides auto-contrast and slider percentiles with fixed bounds
- We follow the same pattern pattern as Show3D: where we have 'None` by default, log scale transform applied when active

From Claude:
- Python: `__init__`, `state_dict`, `summary`, `_normalize_frame`, `save_image'
- JS: DP + VI rendering effects, DP export handler, dependency arrays
- 6 new tests (constructor, state roundtrip, normalize, summary)
- Demo cells in `show4dstem_all_features.ipynb`

## Test plan
- [x] 6 new vmin/vmax tests pass
- [x] Full Show4D suite: 117 passed
- [x] `npm run typecheck` clean
- [ ] Manual: open `show4dstem_all_features.ipynb`, run section 16, click scan positions, DP contrast stays locked