### PR TITLE
Show4DSTEM: add vmin/vmax for absolute intensity range

### DIFF
--- a/js/show4dstem/index.tsx
+++ b/js/show4dstem/index.tsx
@@ -1041,6 +1041,11 @@ function Show4DSTEM() {
   const [dpVmaxPct, setDpVmaxPct] = useModelState<number>("dp_vmax_pct");
   const [viVminPct, setViVminPct] = useModelState<number>("vi_vmin_pct");
   const [viVmaxPct, setViVmaxPct] = useModelState<number>("vi_vmax_pct");
+  // Absolute intensity bounds (override percentile sliders when both set)
+  const [traitDpVmin] = useModelState<number | null>("dp_vmin");
+  const [traitDpVmax] = useModelState<number | null>("dp_vmax");
+  const [traitViVmin] = useModelState<number | null>("vi_vmin");
+  const [traitViVmax] = useModelState<number | null>("vi_vmax");
   // Scale mode: "linear" | "log" | "power"
   const [dpScaleMode, setDpScaleMode] = useModelState<"linear" | "log" | "power">("dp_scale_mode");
   const [dpPowerExp] = useModelState<number>("dp_power_exp");
@@ -1565,8 +1570,22 @@ function Show4DSTEM() {
     // Compute actual min/max of scaled data for normalization
     const { min: dataMin, max: dataMax } = findDataRange(scaled);
 
-    // Apply vmin/vmax percentile clipping
-    const { vmin, vmax } = sliderRange(dataMin, dataMax, dpVminPct, dpVmaxPct);
+    // Apply absolute bounds or percentile clipping
+    let vmin: number, vmax: number;
+    if (traitDpVmin != null && traitDpVmax != null) {
+      if (dpScaleMode === "log") {
+        vmin = Math.log1p(Math.max(traitDpVmin, 0));
+        vmax = Math.log1p(Math.max(traitDpVmax, 0));
+      } else if (dpScaleMode === "power") {
+        vmin = Math.pow(Math.max(traitDpVmin, 0), dpPowerExp);
+        vmax = Math.pow(Math.max(traitDpVmax, 0), dpPowerExp);
+      } else {
+        vmin = traitDpVmin;
+        vmax = traitDpVmax;
+      }
+    } else {
+      ({ vmin, vmax } = sliderRange(dataMin, dataMax, dpVminPct, dpVmaxPct));
+    }
 
     let offscreen = dpOffscreenRef.current;
     if (!offscreen) {
@@ -1593,7 +1612,7 @@ function Show4DSTEM() {
     dpColorbarVminRef.current = vmin;
     dpColorbarVmaxRef.current = vmax;
     setDpOffscreenVersion(v => v + 1);
-  }, [frameBytes, summedDpBytes, viRoiMode, detRows, detCols, dpColormap, dpVminPct, dpVmaxPct, dpScaleMode, dpPowerExp]);
+  }, [frameBytes, summedDpBytes, viRoiMode, detRows, detCols, dpColormap, dpVminPct, dpVmaxPct, dpScaleMode, dpPowerExp, traitDpVmin, traitDpVmax]);
 
   // Cheap: zoom/pan redraw — just drawImage from cached offscreen
   // useLayoutEffect prevents black flash when canvas dimensions change (resize)
@@ -1666,8 +1685,22 @@ function Show4DSTEM() {
       dataMax = r.max;
     }
 
-    // Apply vmin/vmax percentile clipping
-    const { vmin, vmax } = sliderRange(dataMin, dataMax, viVminPct, viVmaxPct);
+    // Apply absolute bounds or percentile clipping
+    let vmin: number, vmax: number;
+    if (traitViVmin != null && traitViVmax != null) {
+      if (viScaleMode === "log") {
+        vmin = Math.log1p(Math.max(traitViVmin, 0));
+        vmax = Math.log1p(Math.max(traitViVmax, 0));
+      } else if (viScaleMode === "power") {
+        vmin = Math.pow(Math.max(traitViVmin, 0), viPowerExp);
+        vmax = Math.pow(Math.max(traitViVmax, 0), viPowerExp);
+      } else {
+        vmin = traitViVmin;
+        vmax = traitViVmax;
+      }
+    } else {
+      ({ vmin, vmax } = sliderRange(dataMin, dataMax, viVminPct, viVmaxPct));
+    }
 
     const lut = COLORMAPS[viColormap] || COLORMAPS.inferno;
     let offscreen = viOffscreenRef.current;
@@ -1694,7 +1727,7 @@ function Show4DSTEM() {
     setViOffscreenVersion(v => v + 1);
     // Note: viDataMin/viDataMax intentionally not in deps - they arrive with virtualImageBytes
     // and we have a fallback if they're stale
-  }, [virtualImageBytes, shapeRows, shapeCols, viColormap, viVminPct, viVmaxPct, viScaleMode, viPowerExp]);
+  }, [virtualImageBytes, shapeRows, shapeCols, viColormap, viVminPct, viVmaxPct, viScaleMode, viPowerExp, traitViVmin, traitViVmax]);
 
   // Cheap: VI zoom/pan redraw — just drawImage from cached offscreen
   React.useLayoutEffect(() => {
@@ -3497,7 +3530,21 @@ function Show4DSTEM() {
     const processed = dpScaleMode === "log" ? applyLogScale(frameData) : frameData;
     const lut = COLORMAPS[dpColormap] || COLORMAPS.inferno;
     const { min: dMin, max: dMax } = findDataRange(processed);
-    const { vmin, vmax } = sliderRange(dMin, dMax, dpVminPct, dpVmaxPct);
+    let vmin: number, vmax: number;
+    if (traitDpVmin != null && traitDpVmax != null) {
+      if (dpScaleMode === "log") {
+        vmin = Math.log1p(Math.max(traitDpVmin, 0));
+        vmax = Math.log1p(Math.max(traitDpVmax, 0));
+      } else if (dpScaleMode === "power") {
+        vmin = Math.pow(Math.max(traitDpVmin, 0), dpPowerExp);
+        vmax = Math.pow(Math.max(traitDpVmax, 0), dpPowerExp);
+      } else {
+        vmin = traitDpVmin;
+        vmax = traitDpVmax;
+      }
+    } else {
+      ({ vmin, vmax } = sliderRange(dMin, dMax, dpVminPct, dpVmaxPct));
+    }
     const offscreen = renderToOffscreen(processed, detCols, detRows, lut, vmin, vmax);
     if (!offscreen) return;
     const kPxAngstrom = kPixelSize > 0 && kCalibrated ? kPixelSize : 0;

--- a/src/quantem/widget/show4dstem.py
+++ b/src/quantem/widget/show4dstem.py
@@ -248,6 +248,12 @@ class Show4DSTEM(anywidget.AnyWidget):
     fft_vmin_pct = traitlets.Float(0.0).tag(sync=True)
     fft_vmax_pct = traitlets.Float(100.0).tag(sync=True)
 
+    # Absolute intensity bounds (override percentile sliders when both set)
+    dp_vmin = traitlets.Float(None, allow_none=True).tag(sync=True)
+    dp_vmax = traitlets.Float(None, allow_none=True).tag(sync=True)
+    vi_vmin = traitlets.Float(None, allow_none=True).tag(sync=True)
+    vi_vmax = traitlets.Float(None, allow_none=True).tag(sync=True)
+
     fft_auto = traitlets.Bool(True).tag(sync=True)
     show_fft = traitlets.Bool(False).tag(sync=True)
     fft_window = traitlets.Bool(True).tag(sync=True)
@@ -418,6 +424,10 @@ class Show4DSTEM(anywidget.AnyWidget):
         show_fft: bool = False,
         fft_window: bool = True,
         show_controls: bool = True,
+        dp_vmin: float | None = None,
+        dp_vmax: float | None = None,
+        vi_vmin: float | None = None,
+        vi_vmax: float | None = None,
         verbose: bool = True,
         state=None,
         **kwargs,
@@ -493,6 +503,10 @@ class Show4DSTEM(anywidget.AnyWidget):
         self.show_fft = show_fft
         self.fft_window = fft_window
         self.show_controls = show_controls
+        self.dp_vmin = dp_vmin
+        self.dp_vmax = dp_vmax
+        self.vi_vmin = vi_vmin
+        self.vi_vmax = vi_vmax
         # Path animation (configured via set_path() or raster())
         self._path_points: list[tuple[int, int]] = []
         # Named user presets saved during this session
@@ -798,6 +812,10 @@ class Show4DSTEM(anywidget.AnyWidget):
             "vi_vmax_pct": self.vi_vmax_pct,
             "fft_vmin_pct": self.fft_vmin_pct,
             "fft_vmax_pct": self.fft_vmax_pct,
+            "dp_vmin": self.dp_vmin,
+            "dp_vmax": self.dp_vmax,
+            "vi_vmin": self.vi_vmin,
+            "vi_vmax": self.vi_vmax,
             "fft_auto": self.fft_auto,
             "show_fft": self.show_fft,
             "fft_window": self.fft_window,
@@ -908,11 +926,17 @@ class Show4DSTEM(anywidget.AnyWidget):
             lines.append(f"ROI:      {self.roi_mode} at ({self.roi_center_row:.1f}, {self.roi_center_col:.1f}) r={self.roi_radius:.1f}")
         if self.vi_roi_mode != "off":
             lines.append(f"VI ROI:   {self.vi_roi_mode} at ({self.vi_roi_center_row:.1f}, {self.vi_roi_center_col:.1f}) r={self.vi_roi_radius:.1f}")
+        dp_contrast = f"{self.dp_vmin_pct:.1f}-{self.dp_vmax_pct:.1f}%"
+        if self.dp_vmin is not None and self.dp_vmax is not None:
+            dp_contrast += f", dp_vmin={self.dp_vmin:.4g}, dp_vmax={self.dp_vmax:.4g}"
         lines.append(
-            f"DP view:  {self.dp_colormap}, {self.dp_scale_mode}, {self.dp_vmin_pct:.1f}-{self.dp_vmax_pct:.1f}%"
+            f"DP view:  {self.dp_colormap}, {self.dp_scale_mode}, {dp_contrast}"
         )
+        vi_contrast = f"{self.vi_vmin_pct:.1f}-{self.vi_vmax_pct:.1f}%"
+        if self.vi_vmin is not None and self.vi_vmax is not None:
+            vi_contrast += f", vi_vmin={self.vi_vmin:.4g}, vi_vmax={self.vi_vmax:.4g}"
         lines.append(
-            f"VI view:  {self.vi_colormap}, {self.vi_scale_mode}, {self.vi_vmin_pct:.1f}-{self.vi_vmax_pct:.1f}%"
+            f"VI view:  {self.vi_colormap}, {self.vi_scale_mode}, {vi_contrast}"
         )
         if self.show_fft:
             fft_parts = [f"{self.fft_colormap}, {self.fft_scale_mode}, {self.fft_vmin_pct:.1f}-{self.fft_vmax_pct:.1f}%, auto={self.fft_auto}"]
@@ -1486,7 +1510,15 @@ class Show4DSTEM(anywidget.AnyWidget):
         scaled = self._apply_scale_mode(raw, scale_mode, self.dp_power_exp)
         data_min = float(scaled.min()) if scaled.size else 0.0
         data_max = float(scaled.max()) if scaled.size else 0.0
-        vmin, vmax = self._slider_range(data_min, data_max, self.dp_vmin_pct, self.dp_vmax_pct)
+        if self.dp_vmin is not None and self.dp_vmax is not None:
+            vmin = float(self._apply_scale_mode(
+                np.array([max(self.dp_vmin, 0)], dtype=np.float32), scale_mode, self.dp_power_exp
+            )[0])
+            vmax = float(self._apply_scale_mode(
+                np.array([max(self.dp_vmax, 0)], dtype=np.float32), scale_mode, self.dp_power_exp
+            )[0])
+        else:
+            vmin, vmax = self._slider_range(data_min, data_max, self.dp_vmin_pct, self.dp_vmax_pct)
         rgb = self._render_colormap_rgb(scaled, self.dp_colormap, vmin, vmax)
         metadata = {
             "source": source,
@@ -1504,7 +1536,15 @@ class Show4DSTEM(anywidget.AnyWidget):
         scaled = self._apply_scale_mode(raw, self.vi_scale_mode, self.vi_power_exp)
         data_min = float(scaled.min()) if scaled.size else 0.0
         data_max = float(scaled.max()) if scaled.size else 0.0
-        vmin, vmax = self._slider_range(data_min, data_max, self.vi_vmin_pct, self.vi_vmax_pct)
+        if self.vi_vmin is not None and self.vi_vmax is not None:
+            vmin = float(self._apply_scale_mode(
+                np.array([max(self.vi_vmin, 0)], dtype=np.float32), self.vi_scale_mode, self.vi_power_exp
+            )[0])
+            vmax = float(self._apply_scale_mode(
+                np.array([max(self.vi_vmax, 0)], dtype=np.float32), self.vi_scale_mode, self.vi_power_exp
+            )[0])
+        else:
+            vmin, vmax = self._slider_range(data_min, data_max, self.vi_vmin_pct, self.vi_vmax_pct)
         rgb = self._render_colormap_rgb(scaled, self.vi_colormap, vmin, vmax)
         metadata = {
             "colormap": self.vi_colormap,
@@ -3898,9 +3938,17 @@ class Show4DSTEM(anywidget.AnyWidget):
     def _normalize_frame(self, frame: np.ndarray) -> np.ndarray:
         mode = self.dp_scale_mode
         scaled = self._apply_scale_mode(frame, mode, self.dp_power_exp)
-        fmin = float(scaled.min())
-        fmax = float(scaled.max())
-        fmin, fmax = self._slider_range(fmin, fmax, self.dp_vmin_pct, self.dp_vmax_pct)
+        if self.dp_vmin is not None and self.dp_vmax is not None:
+            fmin = float(self._apply_scale_mode(
+                np.array([max(self.dp_vmin, 0)], dtype=np.float32), mode, self.dp_power_exp
+            )[0])
+            fmax = float(self._apply_scale_mode(
+                np.array([max(self.dp_vmax, 0)], dtype=np.float32), mode, self.dp_power_exp
+            )[0])
+        else:
+            fmin = float(scaled.min())
+            fmax = float(scaled.max())
+            fmin, fmax = self._slider_range(fmin, fmax, self.dp_vmin_pct, self.dp_vmax_pct)
         if fmax > fmin:
             return np.clip((scaled - fmin) / (fmax - fmin) * 255, 0, 255).astype(np.uint8)
         return np.zeros(frame.shape, dtype=np.uint8)

--- a/tests/test_widget_show4dstem.py
+++ b/tests/test_widget_show4dstem.py
@@ -1113,3 +1113,71 @@ def test_show4dstem_virtual_image_for_frame():
     assert vi.shape == (4, 4)
     assert vi.dtype == np.float32
     assert w.frame_idx == original_frame_idx
+
+
+# ── dp_vmin/dp_vmax + vi_vmin/vi_vmax tests ─────────────────────────────────
+
+
+def test_show4dstem_vmin_vmax_default_none():
+    data = np.random.rand(4, 4, 8, 8).astype(np.float32)
+    w = Show4DSTEM(data)
+    assert w.dp_vmin is None
+    assert w.dp_vmax is None
+    assert w.vi_vmin is None
+    assert w.vi_vmax is None
+
+
+def test_show4dstem_vmin_vmax_constructor():
+    data = np.random.rand(4, 4, 8, 8).astype(np.float32) * 5000
+    w = Show4DSTEM(data, dp_vmin=0, dp_vmax=3000, vi_vmin=10, vi_vmax=500)
+    assert w.dp_vmin == pytest.approx(0)
+    assert w.dp_vmax == pytest.approx(3000)
+    assert w.vi_vmin == pytest.approx(10)
+    assert w.vi_vmax == pytest.approx(500)
+
+
+def test_show4dstem_vmin_vmax_state_dict_roundtrip():
+    data = np.random.rand(4, 4, 8, 8).astype(np.float32) * 5000
+    w = Show4DSTEM(data, dp_vmin=0, dp_vmax=3000, vi_vmin=10, vi_vmax=500)
+    sd = w.state_dict()
+    assert sd["dp_vmin"] == pytest.approx(0)
+    assert sd["dp_vmax"] == pytest.approx(3000)
+    assert sd["vi_vmin"] == pytest.approx(10)
+    assert sd["vi_vmax"] == pytest.approx(500)
+    w2 = Show4DSTEM(data, state=sd)
+    assert w2.dp_vmin == pytest.approx(0)
+    assert w2.dp_vmax == pytest.approx(3000)
+    assert w2.vi_vmin == pytest.approx(10)
+    assert w2.vi_vmax == pytest.approx(500)
+
+
+def test_show4dstem_vmin_vmax_none_in_state_dict():
+    data = np.random.rand(4, 4, 8, 8).astype(np.float32)
+    w = Show4DSTEM(data)
+    sd = w.state_dict()
+    assert sd["dp_vmin"] is None
+    assert sd["dp_vmax"] is None
+    assert sd["vi_vmin"] is None
+    assert sd["vi_vmax"] is None
+
+
+def test_show4dstem_vmin_vmax_normalize_frame():
+    data = np.zeros((2, 2, 2, 2), dtype=np.float32)
+    frame = np.array([[0, 500], [1000, 1500]], dtype=np.float32)
+    w = Show4DSTEM(data, dp_vmin=0, dp_vmax=1000)
+    result = w._normalize_frame(frame)
+    assert result[0, 0] == 0
+    assert result[1, 0] == 255
+    assert result[1, 1] == 255  # clamped
+    assert 120 <= result[0, 1] <= 135  # ~127
+
+
+def test_show4dstem_vmin_vmax_summary(capsys):
+    data = np.random.rand(4, 4, 8, 8).astype(np.float32)
+    w = Show4DSTEM(data, dp_vmin=0, dp_vmax=5000, vi_vmin=10, vi_vmax=500)
+    w.summary()
+    out = capsys.readouterr().out
+    assert "dp_vmin=0" in out
+    assert "dp_vmax=5000" in out
+    assert "vi_vmin=10" in out
+    assert "vi_vmax=500" in out


### PR DESCRIPTION
Same as #116 but addresses #82, we do the following:
- Adds nav_vmin/nav_vmax and sig_vmin/sig_vmax traits to Show4D; when both set, overrides auto-contrast and slider percentiles with fixed bounds
- We follow the same pattern pattern as Show3D: where we have 'None` by default, log scale transform applied when active

From Claude:
- Python: `__init__`, `state_dict`, `summary`, `_normalize_frame`, `_render_dp_rgb`, `_render_virtual_rgb`
- JS: DP + VI rendering effects, DP export handler, dependency arrays
- 6 new tests (constructor, state roundtrip, normalize, summary)
- Demo cells in `show4dstem_all_features.ipynb`

## Test plan
- [x] 6 new vmin/vmax tests pass
- [x] Full Show4DSTEM suite: 117 passed
- [x] `npm run typecheck` clean
- [ ] Manual: open `show4dstem_all_features.ipynb`, run section 16, click scan positions — DP contrast stays locked