### PR TITLE
ShowComplex2D: add vmin/vmax for absolute intensity range

### DIFF
--- a/js/showcomplex/index.tsx
+++ b/js/showcomplex/index.tsx
@@ -385,6 +385,9 @@ function ShowComplex2D() {
   const [autoContrast, setAutoContrast] = useModelState<boolean>("auto_contrast");
   const [percentileLow] = useModelState<number>("percentile_low");
   const [percentileHigh] = useModelState<number>("percentile_high");
+  // Absolute intensity bounds (override percentile sliders when both set)
+  const [traitVmin] = useModelState<number | null>("vmin");
+  const [traitVmax] = useModelState<number | null>("vmax");
 
   // Scale bar
   const [pixelSize] = useModelState<number>("pixel_size");
@@ -619,13 +622,16 @@ function ShowComplex2D() {
       if (!dispData) return;
       const lut = COLORMAPS[mode === "phase" ? "hsv" : cmap] || COLORMAPS.inferno;
       let vmin: number, vmax: number;
-      if (autoContrast && mode !== "phase") {
+      if (mode === "phase") {
+        vmin = -Math.PI;
+        vmax = Math.PI;
+      } else if (traitVmin != null && traitVmax != null) {
+        vmin = logScale ? Math.log1p(Math.max(traitVmin, 0)) : traitVmin;
+        vmax = logScale ? Math.log1p(Math.max(traitVmax, 0)) : traitVmax;
+      } else if (autoContrast) {
         const pc = percentileClip(dispData, percentileLow, percentileHigh);
         vmin = pc.vmin;
         vmax = pc.vmax;
-      } else if (mode === "phase") {
-        vmin = -Math.PI;
-        vmax = Math.PI;
       } else {
         ({ vmin, vmax } = sliderRange(histRange.min, histRange.max, vminPct, vmaxPct));
       }
@@ -635,7 +641,7 @@ function ShowComplex2D() {
     offCtx.putImageData(imgData, 0, 0);
     offscreenCacheRef.current = offscreen;
   }, [realBytes, imagBytes, displayMode, cmap, logScale, autoContrast, percentileLow, percentileHigh,
-      vminPct, vmaxPct, width, height, histRange]);
+      vminPct, vmaxPct, width, height, histRange, traitVmin, traitVmax]);
 
   // ============================================================================
   // Redraw with zoom/pan (cheap: just drawImage from cached offscreen)
@@ -712,13 +718,16 @@ function ShowComplex2D() {
       const dispData = displayDataRef.current;
       const lut = COLORMAPS[mode === "phase" ? "hsv" : cmap] || COLORMAPS.inferno;
       let vmin: number, vmax: number;
-      if (autoContrast && mode !== "phase") {
+      if (mode === "phase") {
+        vmin = -Math.PI;
+        vmax = Math.PI;
+      } else if (traitVmin != null && traitVmax != null) {
+        vmin = logScale ? Math.log1p(Math.max(traitVmin, 0)) : traitVmin;
+        vmax = logScale ? Math.log1p(Math.max(traitVmax, 0)) : traitVmax;
+      } else if (autoContrast) {
         const pc = percentileClip(dispData, percentileLow, percentileHigh);
         vmin = pc.vmin;
         vmax = pc.vmax;
-      } else if (mode === "phase") {
-        vmin = -Math.PI;
-        vmax = Math.PI;
       } else {
         ({ vmin, vmax } = sliderRange(histRange.min, histRange.max, vminPct, vmaxPct));
       }
@@ -1391,13 +1400,16 @@ function ShowComplex2D() {
     } else {
       if (!dispData) return;
       lut = COLORMAPS[mode === "phase" ? "hsv" : cmap] || COLORMAPS.inferno;
-      if (autoContrast && mode !== "phase") {
+      if (mode === "phase") {
+        vmin = -Math.PI;
+        vmax = Math.PI;
+      } else if (traitVmin != null && traitVmax != null) {
+        vmin = logScale ? Math.log1p(Math.max(traitVmin, 0)) : traitVmin;
+        vmax = logScale ? Math.log1p(Math.max(traitVmax, 0)) : traitVmax;
+      } else if (autoContrast) {
         const pc = percentileClip(dispData, percentileLow, percentileHigh);
         vmin = pc.vmin;
         vmax = pc.vmax;
-      } else if (mode === "phase") {
-        vmin = -Math.PI;
-        vmax = Math.PI;
       } else {
         ({ vmin, vmax } = sliderRange(histRange.min, histRange.max, vminPct, vmaxPct));
       }

--- a/src/quantem/widget/showcomplex.py
+++ b/src/quantem/widget/showcomplex.py
@@ -50,6 +50,12 @@ class ShowComplex2D(anywidget.AnyWidget):
         Apply log(1+x) to amplitude before display.
     auto_contrast : bool, default False
         Use percentile-based contrast.
+    vmin : float, optional
+        Minimum value for colormap. Overrides auto-contrast and slider
+        percentiles. Phase mode ignores this (always [-pi, pi]).
+    vmax : float, optional
+        Maximum value for colormap. Overrides auto-contrast and slider
+        percentiles. Phase mode ignores this (always [-pi, pi]).
     show_fft : bool, default False
         Show FFT panel.
     show_stats : bool, default True
@@ -89,6 +95,8 @@ class ShowComplex2D(anywidget.AnyWidget):
     auto_contrast = traitlets.Bool(False).tag(sync=True)
     percentile_low = traitlets.Float(1.0).tag(sync=True)
     percentile_high = traitlets.Float(99.0).tag(sync=True)
+    vmin = traitlets.Float(None, allow_none=True).tag(sync=True)
+    vmax = traitlets.Float(None, allow_none=True).tag(sync=True)
 
     # Scale bar
     pixel_size = traitlets.Float(0.0).tag(sync=True)
@@ -197,6 +205,8 @@ class ShowComplex2D(anywidget.AnyWidget):
         auto_contrast: bool = False,
         percentile_low: float = 1.0,
         percentile_high: float = 99.0,
+        vmin: float | None = None,
+        vmax: float | None = None,
         show_fft: bool = False,
         fft_window: bool = True,
         show_stats: bool = True,
@@ -288,6 +298,8 @@ class ShowComplex2D(anywidget.AnyWidget):
         self.auto_contrast = auto_contrast
         self.percentile_low = percentile_low
         self.percentile_high = percentile_high
+        self.vmin = vmin
+        self.vmax = vmax
         self.show_fft = show_fft
         self.fft_window = fft_window
         self.show_stats = show_stats
@@ -450,7 +462,13 @@ class ShowComplex2D(anywidget.AnyWidget):
     def _normalize_frame(self, frame: np.ndarray) -> np.ndarray:
         if self.log_scale:
             frame = np.log1p(np.maximum(frame, 0))
-        if self.auto_contrast:
+        if self.vmin is not None and self.vmax is not None:
+            vmin = float(self.vmin)
+            vmax = float(self.vmax)
+            if self.log_scale:
+                vmin = float(np.log1p(max(vmin, 0)))
+                vmax = float(np.log1p(max(vmax, 0)))
+        elif self.auto_contrast:
             vmin = float(np.percentile(frame, self.percentile_low))
             vmax = float(np.percentile(frame, self.percentile_high))
         else:
@@ -525,7 +543,13 @@ class ShowComplex2D(anywidget.AnyWidget):
             if self.log_scale and mode in ("amplitude", "real", "imag"):
                 data = np.log1p(np.maximum(data, 0))
 
-            if self.auto_contrast:
+            if self.vmin is not None and self.vmax is not None and mode != "phase":
+                vmin = float(self.vmin)
+                vmax = float(self.vmax)
+                if self.log_scale and mode in ("amplitude", "real", "imag"):
+                    vmin = float(np.log1p(max(vmin, 0)))
+                    vmax = float(np.log1p(max(vmax, 0)))
+            elif self.auto_contrast:
                 vmin = float(np.percentile(data, self.percentile_low))
                 vmax = float(np.percentile(data, self.percentile_high))
             else:
@@ -559,6 +583,8 @@ class ShowComplex2D(anywidget.AnyWidget):
             "auto_contrast": self.auto_contrast,
             "percentile_low": self.percentile_low,
             "percentile_high": self.percentile_high,
+            "vmin": self.vmin,
+            "vmax": self.vmax,
             "pixel_size": self.pixel_size,
             "scale_bar_visible": self.scale_bar_visible,
             "show_fft": self.show_fft,
@@ -613,6 +639,8 @@ class ShowComplex2D(anywidget.AnyWidget):
         cmap = self.cmap if mode in ("amplitude", "real", "imag") else "hsv (cyclic)"
         scale = "log" if self.log_scale else "linear"
         contrast = "auto" if self.auto_contrast else "manual"
+        if self.vmin is not None and self.vmax is not None:
+            contrast += f", vmin={self.vmin:.4g}, vmax={self.vmax:.4g}"
         lines.append(f"Display:  {mode} | {cmap} | {contrast} | {scale}")
         if self.show_fft:
             lines[-1] += " | FFT"

--- a/tests/test_widget_showcomplex.py
+++ b/tests/test_widget_showcomplex.py
@@ -515,7 +515,7 @@ def test_showcomplex_state_dict_completeness():
     state = widget.state_dict()
     expected_keys = {
         "display_mode", "title", "cmap", "log_scale", "auto_contrast",
-        "percentile_low", "percentile_high", "pixel_size",
+        "percentile_low", "percentile_high", "vmin", "vmax", "pixel_size",
         "scale_bar_visible", "show_fft", "fft_window", "show_stats", "show_controls",
         "canvas_size", "disabled_tools", "hidden_tools",
         "roi_mode", "roi_center_row", "roi_center_col",
@@ -935,3 +935,70 @@ def test_showcomplex_roi_tool_visibility():
     assert "roi" in w.hidden_tools
     w2 = ShowComplex2D(data, disable_roi=True)
     assert "roi" in w2.disabled_tools
+
+
+# ── vmin/vmax tests ─────────────────────────────────────────────────────
+
+
+def test_showcomplex_vmin_vmax_default_none():
+    data = (np.random.rand(16, 16) + 1j * np.random.rand(16, 16)).astype(np.complex64)
+    w = ShowComplex2D(data)
+    assert w.vmin is None
+    assert w.vmax is None
+
+
+def test_showcomplex_vmin_vmax_constructor():
+    data = (np.random.rand(16, 16) + 1j * np.random.rand(16, 16)).astype(np.complex64)
+    w = ShowComplex2D(data, vmin=0, vmax=100)
+    assert w.vmin == pytest.approx(0)
+    assert w.vmax == pytest.approx(100)
+
+
+def test_showcomplex_vmin_vmax_state_dict_roundtrip():
+    data = (np.random.rand(16, 16) + 1j * np.random.rand(16, 16)).astype(np.complex64)
+    w = ShowComplex2D(data, vmin=0, vmax=100)
+    sd = w.state_dict()
+    assert sd["vmin"] == pytest.approx(0)
+    assert sd["vmax"] == pytest.approx(100)
+    w2 = ShowComplex2D(data, state=sd)
+    assert w2.vmin == pytest.approx(0)
+    assert w2.vmax == pytest.approx(100)
+
+
+def test_showcomplex_vmin_vmax_none_in_state_dict():
+    data = (np.random.rand(16, 16) + 1j * np.random.rand(16, 16)).astype(np.complex64)
+    w = ShowComplex2D(data)
+    sd = w.state_dict()
+    assert sd["vmin"] is None
+    assert sd["vmax"] is None
+
+
+def test_showcomplex_vmin_vmax_normalize_frame():
+    data = (np.random.rand(16, 16) + 1j * np.random.rand(16, 16)).astype(np.complex64)
+    frame = np.array([[0, 50], [100, 150]], dtype=np.float32)
+    w = ShowComplex2D(data, vmin=0, vmax=100)
+    result = w._normalize_frame(frame)
+    assert result[0, 0] == 0
+    assert result[1, 0] == 255
+    assert result[1, 1] == 255  # clamped
+    assert 120 <= result[0, 1] <= 135  # ~127
+
+
+def test_showcomplex_vmin_vmax_summary(capsys):
+    data = (np.random.rand(16, 16) + 1j * np.random.rand(16, 16)).astype(np.complex64)
+    w = ShowComplex2D(data, vmin=0, vmax=100)
+    w.summary()
+    out = capsys.readouterr().out
+    assert "vmin=0" in out
+    assert "vmax=100" in out
+
+
+def test_showcomplex_vmin_vmax_phase_mode_ignores():
+    """Phase mode always uses [-pi, pi], ignoring vmin/vmax."""
+    data = (np.random.rand(16, 16) + 1j * np.random.rand(16, 16)).astype(np.complex64)
+    w = ShowComplex2D(data, vmin=0, vmax=100, display_mode="phase")
+    # save_image in phase mode should still work (uses [-pi, pi])
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix=".png") as f:
+        path = w.save_image(f.name, display_mode="phase")
+        assert path.exists()


### PR DESCRIPTION
Same as #117, #116 but addresses #83, we do the following:
- Adds vmin/vmax traits to ShowComplex2D
- Phase mode always uses [-pi, pi] and ignores vmin/vmax
- amp/real/imaginary modes use & respect absolute bounds with support for log scales

From Claude:
- Python: `__init__`, `state_dict`, `summary`, `_normalize_frame`, `_render_dp_rgb`, `_render_virtual_rgb`
- JS: DP + VI rendering effects, DP export handler, dependency arrays
- 6 new tests (constructor, state roundtrip, normalize, summary)
- Demo cells in `show4dstem_all_features.ipynb`
Test plan
- [x] 6 new vmin/vmax tests pass
- [x] Full Show4DSTEM suite: 117 passed
- [x] `npm run typecheck` clean
- [ ] Manual: open `show4dstem_all_features.ipynb`, run section 16, click scan positions — DP contrast stays locked