### PR TITLE
add com/dpc imaging modes to show4dstem

### DIFF
--- a/js/show4dstem/index.tsx
+++ b/js/show4dstem/index.tsx
@@ -1102,6 +1102,7 @@ function Show4DSTEM() {
   const lockFrame = toolVisibility.isLocked("frame");
   const lockFft = toolVisibility.isLocked("fft") || lockVirtual;
   const effectiveShowFft = showFft && !hideFft;
+  const isComMode = roiMode?.startsWith("com_") || roiMode === "icom" || roiMode === "dcom" || roiMode === "curl";
 
   // ROI FFT state (VI ROI crops virtual image for FFT)
   const [fftCropDims, setFftCropDims] = React.useState<{ cropWidth: number; cropHeight: number; fftWidth: number; fftHeight: number } | null>(null);
@@ -3785,6 +3786,8 @@ function Show4DSTEM() {
                   <Typography component="span" onClick={() => { if (!lockRoi) { setRoiMode("circle"); setRoiRadius(bfRadius || 10); setRoiCenterCol(centerCol); setRoiCenterRow(centerRow); } }} sx={{ color: roiColors.textColor, fontSize: 11, fontWeight: "bold", cursor: lockRoi ? "default" : "pointer", opacity: lockRoi ? 0.6 : 1, "&:hover": { textDecoration: lockRoi ? "none" : "underline" } }}>BF</Typography>
                   <Typography component="span" onClick={() => { if (!lockRoi) { setRoiMode("annular"); setRoiRadiusInner((bfRadius || 10) * 0.5); setRoiRadius(bfRadius || 10); setRoiCenterCol(centerCol); setRoiCenterRow(centerRow); } }} sx={{ color: "#4af", fontSize: 11, fontWeight: "bold", cursor: lockRoi ? "default" : "pointer", opacity: lockRoi ? 0.6 : 1, "&:hover": { textDecoration: lockRoi ? "none" : "underline" } }}>ABF</Typography>
                   <Typography component="span" onClick={() => { if (!lockRoi) { setRoiMode("annular"); setRoiRadiusInner(bfRadius || 10); setRoiRadius(Math.min((bfRadius || 10) * 3, Math.min(detRows, detCols) / 2 - 2)); setRoiCenterCol(centerCol); setRoiCenterRow(centerRow); } }} sx={{ color: "#fa4", fontSize: 11, fontWeight: "bold", cursor: lockRoi ? "default" : "pointer", opacity: lockRoi ? 0.6 : 1, "&:hover": { textDecoration: lockRoi ? "none" : "underline" } }}>ADF</Typography>
+                  <Typography component="span" onClick={() => { if (!lockRoi) { setRoiMode("com_mag"); } }} sx={{ color: "#f6a", fontSize: 11, fontWeight: "bold", cursor: lockRoi ? "default" : "pointer", opacity: lockRoi ? 0.6 : 1, "&:hover": { textDecoration: lockRoi ? "none" : "underline" } }}>COM</Typography>
+                  <Typography component="span" onClick={() => { if (!lockRoi) { setRoiMode("icom"); } }} sx={{ color: "#a6f", fontSize: 11, fontWeight: "bold", cursor: lockRoi ? "default" : "pointer", opacity: lockRoi ? 0.6 : 1, "&:hover": { textDecoration: lockRoi ? "none" : "underline" } }}>iCOM</Typography>
                 </>
               )}
             </Box>
@@ -3825,8 +3828,14 @@ function Show4DSTEM() {
                       <MenuItem value="square">Square</MenuItem>
                       <MenuItem value="rect">Rect</MenuItem>
                       <MenuItem value="annular">Annular</MenuItem>
+                      <MenuItem value="com_x">COM-X</MenuItem>
+                      <MenuItem value="com_y">COM-Y</MenuItem>
+                      <MenuItem value="com_mag">COM Mag</MenuItem>
+                      <MenuItem value="icom">iCOM</MenuItem>
+                      <MenuItem value="dcom">dCOM</MenuItem>
+                      <MenuItem value="curl">Curl</MenuItem>
                     </Select>
-                    {(roiMode === "circle" || roiMode === "square" || roiMode === "annular") && (
+                    {!isComMode && (roiMode === "circle" || roiMode === "square" || roiMode === "annular") && (
                       <>
                         <Slider
                           value={roiMode === "annular" ? [roiRadiusInner, roiRadius] : [roiRadius]}

--- a/notebooks/show4dstem/show4dstem_com_dpc_arina.ipynb
+++ b/notebooks/show4dstem/show4dstem_com_dpc_arina.ipynb
@@ -1,0 +1,448 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "header",
+   "metadata": {},
+   "source": [
+    "# COM / DPC Imaging w/ data from Arina detector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "setup",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n",
+      "env: ANYWIDGET_HMR=1\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "%env ANYWIDGET_HMR=1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, glob, numpy as np\n",
+    "from quantem.widget import IO, Show4DSTEM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "load",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "KoreanSampleC1Bob_04_master.h5\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "83cc83f08bac4454a41c669cf096c598",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "GPU:   0%|          | 0/20 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "load_arina: 65536 frames, det (192,192) → (48,48), 1.67s\n",
+      "hot pixel filter: 4 pixels zeroed (5.0σ threshold)\n",
+      "\n",
+      "(256, 256, 48, 48), float32\n"
+     ]
+    }
+   ],
+   "source": [
+    "DATA_DIR = os.path.expanduser(\"~/Desktop/_Research/_quantem-workspace/quantem.widget/notebooks/io/koreansampleh5\")\n",
+    "masters = sorted(glob.glob(os.path.join(DATA_DIR, \"*_master.h5\")))\n",
+    "assert masters, f\"No *_master.h5 found in {DATA_DIR}\"\n",
+    "for m in masters:\n",
+    "    print(os.path.basename(m))\n",
+    "\n",
+    "result = IO.arina_file(masters[0], det_bin=4)\n",
+    "print(f\"\\n{result.data.shape}, {result.data.dtype}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "basic-view",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  to mps: 0.23s (0.6 GB)\n",
+      "  auto_detect_center: 0.03s\n",
+      "  virtual image + frame: 0.01s\n",
+      "Show4DSTEM: 256x256x48x48 mps, 0.36s total\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6f41e734f1184cfe86e17d2017c959e4",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Show4DSTEM(shape=(256, 256, 48, 48), sampling=(1.0 Å, 1.0 px), pos=(128, 128), title='KoreanSampleC1Bob_04')"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "w = Show4DSTEM(result)\n",
+    "w"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "icom",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  to mps: 0.12s (0.6 GB)\n",
+      "  auto_detect_center: 0.01s\n",
+      "  virtual image + frame: 0.03s\n",
+      "Show4DSTEM: 256x256x48x48 mps, 0.21s total\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dd9400d5061f4e978437a0d047a33cff",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Show4DSTEM(shape=(256, 256, 48, 48), sampling=(1.0 Å, 1.0 px), pos=(128, 128), title='iCOM')"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "w_icom = Show4DSTEM(result, title=\"iCOM\")\n",
+    "w_icom.roi_mode = \"icom\"\n",
+    "w_icom"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "com-mag",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  to mps: 0.04s (0.6 GB)\n",
+      "  auto_detect_center: 0.01s\n",
+      "  virtual image + frame: 0.00s\n",
+      "Show4DSTEM: 256x256x48x48 mps, 0.08s total\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "48ee2a74b855495b9f3ad5a37ee2b6f0",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Show4DSTEM(shape=(256, 256, 48, 48), sampling=(1.0 Å, 1.0 px), pos=(128, 128), title='COM magnitude')"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "w_mag = Show4DSTEM(result, title=\"COM magnitude\")\n",
+    "w_mag.roi_mode = \"com_mag\"\n",
+    "w_mag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "all-modes",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  to mps: 0.07s (0.6 GB)\n",
+      "  auto_detect_center: 0.01s\n",
+      "  virtual image + frame: 0.00s\n",
+      "Show4DSTEM: 256x256x48x48 mps, 0.12s total\n",
+      "  com_x   : [-0.6736, 0.6765], std=0.1654\n",
+      "  com_y   : [-1.1082, 0.8406], std=0.2648\n",
+      "  com_mag : [0.0009, 1.1090], std=0.1645\n",
+      "  icom    : [-76.1238, 84.4219], std=38.2383\n",
+      "  dcom    : [-0.3438, 0.4221], std=0.0878\n",
+      "  curl    : [-0.3310, 0.2945], std=0.0512\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f6d9d4b25292413990d67e607f05d5e0",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Show4DSTEM(shape=(256, 256, 48, 48), sampling=(1.0 Å, 1.0 px), pos=(128, 128), title='COM/DPC stats')"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "w_all = Show4DSTEM(result, title=\"COM/DPC stats\")\n",
+    "sr, sc = w_all.shape_rows, w_all.shape_cols\n",
+    "for mode in [\"com_x\", \"com_y\", \"com_mag\", \"icom\", \"dcom\", \"curl\"]:\n",
+    "    w_all.roi_mode = mode\n",
+    "    vi = np.frombuffer(w_all.virtual_image_bytes, dtype=np.float32).reshape(sr, sc)\n",
+    "    print(f\"  {mode:8s}: [{vi.min():.4f}, {vi.max():.4f}], std={vi.std():.4f}\")\n",
+    "w_all.roi_mode = \"icom\"\n",
+    "w_all"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "dcom-curl",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  to mps: 0.03s (0.6 GB)\n",
+      "  auto_detect_center: 0.01s\n",
+      "  virtual image + frame: 0.01s\n",
+      "Show4DSTEM: 256x256x48x48 mps, 0.06s total\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ac31febf54b44bf2bc9068c83d5dec80",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Show4DSTEM(shape=(256, 256, 48, 48), sampling=(1.0 Å, 1.0 px), pos=(128, 128), title='dCOM')"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "w_dc = Show4DSTEM(result, title=\"dCOM\")\n",
+    "w_dc.roi_mode = \"dcom\"\n",
+    "w_dc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "curl",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  to mps: 0.05s (0.6 GB)\n",
+      "  auto_detect_center: 0.01s\n",
+      "  virtual image + frame: 0.00s\n",
+      "Show4DSTEM: 256x256x48x48 mps, 0.08s total\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3dd87469003d463ba0a95275810f49cb",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Show4DSTEM(shape=(256, 256, 48, 48), sampling=(1.0 Å, 1.0 px), pos=(128, 128), title='Curl')"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "w_curl = Show4DSTEM(result, title=\"Curl\")\n",
+    "w_curl.roi_mode = \"curl\"\n",
+    "w_curl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "com-xy",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  to mps: 0.03s (0.6 GB)\n",
+      "  auto_detect_center: 0.01s\n",
+      "  virtual image + frame: 0.00s\n",
+      "Show4DSTEM: 256x256x48x48 mps, 0.08s total\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aaeeeb78416a415e95dbeb3c86e30882",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Show4DSTEM(shape=(256, 256, 48, 48), sampling=(1.0 Å, 1.0 px), pos=(128, 128), title='COM-X')"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "w_x = Show4DSTEM(result, title=\"COM-X\")\n",
+    "w_x.roi_mode = \"com_x\"\n",
+    "w_x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "com-y",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  to mps: 0.03s (0.6 GB)\n",
+      "  auto_detect_center: 0.01s\n",
+      "  virtual image + frame: 0.00s\n",
+      "Show4DSTEM: 256x256x48x48 mps, 0.06s total\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9e7ad9233dda48a8ac2575acad694d74",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Show4DSTEM(shape=(256, 256, 48, 48), sampling=(1.0 Å, 1.0 px), pos=(128, 128), title='COM-Y')"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "w_y = Show4DSTEM(result, title=\"COM-Y\")\n",
+    "w_y.roi_mode = \"com_y\"\n",
+    "w_y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "cleanup",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "freed 576 MB (mps)\n",
+      "freed 576 MB (mps)\n",
+      "freed 576 MB (mps)\n",
+      "freed 576 MB (mps)\n",
+      "freed 576 MB (mps)\n",
+      "freed 576 MB (mps)\n",
+      "freed 576 MB (mps)\n",
+      "freed 576 MB (mps)\n"
+     ]
+    }
+   ],
+   "source": [
+    "for w in [w, w_icom, w_mag, w_all, w_dc, w_curl, w_x, w_y]:\n",
+    "    w.free()\n",
+    "del result"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/quantem/widget/show4dstem.py
+++ b/src/quantem/widget/show4dstem.py
@@ -629,6 +629,8 @@ class Show4DSTEM(anywidget.AnyWidget):
         self._cached_bf_virtual = None
         self._cached_abf_virtual = None
         self._cached_adf_virtual = None
+        self._cached_com_row = None
+        self._cached_com_col = None
         if precompute_virtual_images and self.n_frames == 1:
             self._precompute_common_virtual_images()
 
@@ -750,6 +752,8 @@ class Show4DSTEM(anywidget.AnyWidget):
         self._cached_bf_virtual = None
         self._cached_abf_virtual = None
         self._cached_adf_virtual = None
+        self._cached_com_row = None
+        self._cached_com_col = None
         with self.hold_trait_notifications():
             self.pos_row = min(self.pos_row, self.shape_rows - 1)
             self.pos_col = min(self.pos_col, self.shape_cols - 1)
@@ -879,6 +883,8 @@ class Show4DSTEM(anywidget.AnyWidget):
         device = str(self._device) if hasattr(self, "_device") else ""
         nbytes = self._data.nbytes if hasattr(self._data, "nbytes") else 0
         self._data = None
+        self._cached_com_row = None
+        self._cached_com_col = None
         gc.collect()
         if device == "mps":
             try:
@@ -1144,6 +1150,8 @@ class Show4DSTEM(anywidget.AnyWidget):
         self._cached_bf_virtual = None
         self._cached_abf_virtual = None
         self._cached_adf_virtual = None
+        self._cached_com_row = None
+        self._cached_com_col = None
         # Recompute virtual image and displayed frame
         self._compute_virtual_image_from_roi()
         self._update_frame()
@@ -1382,6 +1390,10 @@ class Show4DSTEM(anywidget.AnyWidget):
         self.center_col = cx
         self.center_row = cy
         self.bf_radius = radius
+
+        # Invalidate COM caches (they depend on center/bf_radius)
+        self._cached_com_row = None
+        self._cached_com_col = None
 
         if update_roi:
             # Also update ROI to center
@@ -4186,6 +4198,167 @@ class Show4DSTEM(anywidget.AnyWidget):
             float(adf_arr.min()), float(adf_arr.max())
         )
 
+    def _compute_com_maps(self):
+        if hasattr(self, "_cached_com_row") and self._cached_com_row is not None:
+            return
+
+        data = self._frame_data
+
+        # Coordinate grids relative to BF center
+        q_row = torch.arange(self.det_rows, device=self._device, dtype=torch.float32) - self.center_row
+        q_col = torch.arange(self.det_cols, device=self._device, dtype=torch.float32) - self.center_col
+        q_row_2d = q_row[:, None]
+        q_col_2d = q_col[None, :]
+
+        # Mask to 2× BF radius to reduce noise from outer detector regions
+        bf_mask = (q_row_2d**2 + q_col_2d**2) <= (self.bf_radius * 2) ** 2
+
+        if data.ndim == 3:
+            data_4d = data.reshape(
+                self._scan_shape[0], self._scan_shape[1], *self._det_shape
+            )
+        else:
+            data_4d = data
+
+        masked = data_4d * bf_mask[None, None].float()
+        intensity_sum = masked.sum(dim=(-2, -1)).clamp(min=1e-10)
+
+        com_row = (masked * q_row_2d[None, None]).sum(dim=(-2, -1)) / intensity_sum
+        com_col = (masked * q_col_2d[None, None]).sum(dim=(-2, -1)) / intensity_sum
+
+        # Clean NaN/Inf from dead pixels or zero-intensity positions
+        com_row = torch.nan_to_num(com_row, nan=0.0, posinf=0.0, neginf=0.0)
+        com_col = torch.nan_to_num(com_col, nan=0.0, posinf=0.0, neginf=0.0)
+
+        # Plane-fit background subtraction (removes descan gradients)
+        # Fits ax + by + c to each COM component and subtracts
+        com_row = self._subtract_plane_fit(com_row)
+        com_col = self._subtract_plane_fit(com_col)
+
+        # Auto-rotate to minimize curl (aligns scan ↔ diffraction coordinates)
+        com_row, com_col = self._auto_rotate_com(com_row, com_col)
+
+        self._cached_com_row = com_row
+        self._cached_com_col = com_col
+
+    @staticmethod
+    def _subtract_plane_fit(arr: torch.Tensor) -> torch.Tensor:
+        n_rows, n_cols = arr.shape
+        device = arr.device
+        row_coords = torch.arange(n_rows, device=device, dtype=torch.float32) / max(n_rows - 1, 1)
+        col_coords = torch.arange(n_cols, device=device, dtype=torch.float32) / max(n_cols - 1, 1)
+        row_grid, col_grid = torch.meshgrid(row_coords, col_coords, indexing="ij")
+        # Least-squares: arr ≈ a*row + b*col + c (normal equations)
+        design = torch.stack(
+            [row_grid.ravel(), col_grid.ravel(), torch.ones(n_rows * n_cols, device=device)],
+            dim=1,
+        )
+        target = arr.ravel()
+        gram = design.T @ design
+        moment = design.T @ target
+        coeffs = torch.linalg.solve(gram, moment)
+        plane = coeffs[0] * row_grid + coeffs[1] * col_grid + coeffs[2]
+        return arr - plane
+
+    @staticmethod
+    def _auto_rotate_com(com_row: torch.Tensor, com_col: torch.Tensor):
+        com_row_np = com_row.cpu().numpy()
+        com_col_np = com_col.cpu().numpy()
+        best_angle = 0.0
+        best_curl = np.inf
+        # Search rotation that minimizes mean |curl|
+        for angle_deg in range(-90, 91, 5):
+            rad = np.radians(angle_deg)
+            cos_a, sin_a = np.cos(rad), np.sin(rad)
+            rot_row = cos_a * com_row_np - sin_a * com_col_np
+            rot_col = sin_a * com_row_np + cos_a * com_col_np
+            curl = np.gradient(rot_col, axis=0) - np.gradient(rot_row, axis=1)
+            curl_metric = np.abs(curl).mean()
+            if curl_metric < best_curl:
+                best_curl = curl_metric
+                best_angle = angle_deg
+        # Refine around best angle (±5° in 1° steps)
+        for angle_deg in range(best_angle - 5, best_angle + 6):
+            rad = np.radians(angle_deg)
+            cos_a, sin_a = np.cos(rad), np.sin(rad)
+            rot_row = cos_a * com_row_np - sin_a * com_col_np
+            rot_col = sin_a * com_row_np + cos_a * com_col_np
+            curl = np.gradient(rot_col, axis=0) - np.gradient(rot_row, axis=1)
+            curl_metric = np.abs(curl).mean()
+            if curl_metric < best_curl:
+                best_curl = curl_metric
+                best_angle = angle_deg
+        # Apply best rotation
+        if best_angle != 0:
+            rad = np.radians(best_angle)
+            cos_a, sin_a = np.cos(rad), np.sin(rad)
+            rot_row = cos_a * com_row_np - sin_a * com_col_np
+            rot_col = sin_a * com_row_np + cos_a * com_col_np
+            return (
+                torch.from_numpy(rot_row.astype(np.float32)).to(com_row.device),
+                torch.from_numpy(rot_col.astype(np.float32)).to(com_col.device),
+            )
+        return com_row, com_col
+
+    def _get_com_derived(self, mode: str) -> torch.Tensor:
+        self._compute_com_maps()
+        cached_row = self._cached_com_row
+        cached_col = self._cached_com_col
+
+        if mode == "com_x":
+            return cached_col
+        elif mode == "com_y":
+            return cached_row
+        elif mode == "com_mag":
+            return (cached_row**2 + cached_col**2).sqrt()
+        elif mode == "icom":
+            return self._compute_icom(cached_row, cached_col)
+        elif mode == "dcom":
+            com_row_np = cached_row.cpu().numpy()
+            com_col_np = cached_col.cpu().numpy()
+            divergence = np.gradient(com_col_np, axis=1) + np.gradient(com_row_np, axis=0)
+            return torch.from_numpy(divergence.astype(np.float32)).to(self._device)
+        elif mode == "curl":
+            com_row_np = cached_row.cpu().numpy()
+            com_col_np = cached_col.cpu().numpy()
+            curl = np.gradient(com_col_np, axis=0) - np.gradient(com_row_np, axis=1)
+            return torch.from_numpy(curl.astype(np.float32)).to(self._device)
+        else:
+            raise ValueError(f"Unknown COM mode: {mode!r}")
+
+    def _compute_icom(self, com_row, com_col):
+        com_row_np = com_row.cpu().numpy().astype(np.float64)
+        com_col_np = com_col.cpu().numpy().astype(np.float64)
+        n_rows, n_cols = com_row_np.shape
+
+        # Apply Hann window to taper edges — eliminates boundary discontinuity
+        window = np.hanning(n_rows)[:, None] * np.hanning(n_cols)[None, :]
+        com_row_np = com_row_np * window
+        com_col_np = com_col_np * window
+
+        # Zero-pad to 2x size to reduce periodic boundary artifacts
+        pad_rows, pad_cols = n_rows * 2, n_cols * 2
+        row_pad = np.zeros((pad_rows, pad_cols), dtype=np.float64)
+        col_pad = np.zeros((pad_rows, pad_cols), dtype=np.float64)
+        row_pad[:n_rows, :n_cols] = com_row_np
+        col_pad[:n_rows, :n_cols] = com_col_np
+
+        freq_row = np.fft.fftfreq(pad_rows)
+        freq_col = np.fft.fftfreq(pad_cols)
+        freq_row_2d, freq_col_2d = np.meshgrid(freq_row, freq_col, indexing="ij")
+        freq_sq = freq_row_2d**2 + freq_col_2d**2
+        freq_sq[0, 0] = 1.0  # avoid division by zero at DC
+
+        fft_row = np.fft.fft2(row_pad)
+        fft_col = np.fft.fft2(col_pad)
+
+        # Fourier-space Poisson integration: V = -F^{-1}[(i*kr*Fr + i*kc*Fc) / k^2]
+        fft_potential = -(1j * freq_row_2d * fft_row + 1j * freq_col_2d * fft_col) / freq_sq
+        fft_potential[0, 0] = 0.0
+
+        potential = np.real(np.fft.ifft2(fft_potential))[:n_rows, :n_cols].astype(np.float32)
+        return torch.from_numpy(potential).to(self._device)
+
     def _get_cached_preset(self) -> tuple[bytes, list[float], float, float] | None:
         """Check if current ROI matches a cached preset and return (bytes, stats, min, max) tuple."""
         # Must be centered on detector center
@@ -4214,6 +4387,23 @@ class Show4DSTEM(anywidget.AnyWidget):
 
     def _virtual_image_for_frame(self, frame_idx: int) -> np.ndarray:
         """Compute virtual image array for a specific frame without mutating traits."""
+        # COM/DPC modes: return the cached/computed map for this frame
+        if self.roi_mode in ("com_x", "com_y", "com_mag", "icom", "dcom", "curl"):
+            # For per-frame export, temporarily switch frame context if needed
+            orig_frame_idx = self.frame_idx
+            if self.n_frames > 1 and frame_idx != self.frame_idx:
+                # Invalidate COM cache and switch frame
+                self._cached_com_row = None
+                self._cached_com_col = None
+                self.frame_idx = frame_idx
+            arr = self._get_com_derived(self.roi_mode)
+            arr_np = arr.cpu().numpy() if hasattr(arr, "cpu") else arr
+            if self.n_frames > 1 and frame_idx != orig_frame_idx:
+                self._cached_com_row = None
+                self._cached_com_col = None
+                self.frame_idx = orig_frame_idx
+            return arr_np.astype(np.float32, copy=False)
+
         data = self._data[frame_idx] if self.n_frames > 1 else self._data
         cx, cy = self.roi_center_col, self.roi_center_row
         if self.roi_mode == "circle" and self.roi_radius > 0:
@@ -4308,6 +4498,22 @@ class Show4DSTEM(anywidget.AnyWidget):
             self.vi_stats = vi_stats
             self.vi_data_min = vi_min
             self.vi_data_max = vi_max
+            return
+
+        # COM/DPC modes: compute scalar maps from center-of-mass displacements
+        if self.roi_mode in ("com_x", "com_y", "com_mag", "icom", "dcom", "curl"):
+            arr = self._get_com_derived(self.roi_mode)
+            arr_np = arr.cpu().numpy() if hasattr(arr, "cpu") else arr
+            vi_arr = arr_np.astype(np.float32)
+            self.vi_stats = [
+                float(vi_arr.mean()),
+                float(vi_arr.min()),
+                float(vi_arr.max()),
+                float(vi_arr.std()),
+            ]
+            self.vi_data_min = float(vi_arr.min())
+            self.vi_data_max = float(vi_arr.max())
+            self.virtual_image_bytes = vi_arr.tobytes()
             return
 
         cx, cy = self.roi_center_col, self.roi_center_row

--- a/src/quantem/widget/show4dstem.py
+++ b/src/quantem/widget/show4dstem.py
@@ -4331,28 +4331,22 @@ class Show4DSTEM(anywidget.AnyWidget):
         com_col_np = com_col.cpu().numpy().astype(np.float64)
         n_rows, n_cols = com_row_np.shape
 
-        # Apply Hann window to taper edges — eliminates boundary discontinuity
-        window = np.hanning(n_rows)[:, None] * np.hanning(n_cols)[None, :]
-        com_row_np = com_row_np * window
-        com_col_np = com_col_np * window
+        # Mirror-pad to make boundaries continuous (avoids Hann window dome artifact)
+        pad_row = np.concatenate([com_row_np, com_row_np[::-1]], axis=0)
+        pad_row = np.concatenate([pad_row, pad_row[:, ::-1]], axis=1)
+        pad_col = np.concatenate([com_col_np, com_col_np[::-1]], axis=0)
+        pad_col = np.concatenate([pad_col, pad_col[:, ::-1]], axis=1)
 
-        # Zero-pad to 2x size to reduce periodic boundary artifacts
-        pad_rows, pad_cols = n_rows * 2, n_cols * 2
-        row_pad = np.zeros((pad_rows, pad_cols), dtype=np.float64)
-        col_pad = np.zeros((pad_rows, pad_cols), dtype=np.float64)
-        row_pad[:n_rows, :n_cols] = com_row_np
-        col_pad[:n_rows, :n_cols] = com_col_np
-
+        pad_rows, pad_cols = pad_row.shape
         freq_row = np.fft.fftfreq(pad_rows)
         freq_col = np.fft.fftfreq(pad_cols)
         freq_row_2d, freq_col_2d = np.meshgrid(freq_row, freq_col, indexing="ij")
         freq_sq = freq_row_2d**2 + freq_col_2d**2
-        freq_sq[0, 0] = 1.0  # avoid division by zero at DC
+        freq_sq[0, 0] = 1.0
 
-        fft_row = np.fft.fft2(row_pad)
-        fft_col = np.fft.fft2(col_pad)
+        fft_row = np.fft.fft2(pad_row)
+        fft_col = np.fft.fft2(pad_col)
 
-        # Fourier-space Poisson integration: V = -F^{-1}[(i*kr*Fr + i*kc*Fc) / k^2]
         fft_potential = -(1j * freq_row_2d * fft_row + 1j * freq_col_2d * fft_col) / freq_sq
         fft_potential[0, 0] = 0.0
 

--- a/tests/test_widget_show4dstem.py
+++ b/tests/test_widget_show4dstem.py
@@ -1115,6 +1115,111 @@ def test_show4dstem_virtual_image_for_frame():
     assert w.frame_idx == original_frame_idx
 
 
+# ── COM/DPC Virtual Imaging ────────────────────────────────────────
+
+
+def _make_shifted_4dstem(scan_rows=8, scan_cols=8, det_rows=32, det_cols=32):
+    """4D-STEM with BF disk position varying linearly across scan."""
+    data = np.zeros((scan_rows, scan_cols, det_rows, det_cols), dtype=np.float32)
+    cr, cc = det_rows // 2, det_cols // 2
+    rr, ccc = np.mgrid[:det_rows, :det_cols]
+    for i in range(scan_rows):
+        shift = 2.0 * (i / max(scan_rows - 1, 1))
+        disk = ((rr - cr) ** 2 + (ccc - (cc + shift)) ** 2 < 4**2).astype(np.float32)
+        data[i, :] = disk[None]
+    return data
+
+
+def test_show4dstem_com_modes():
+    """COM modes produce valid virtual images."""
+    data = _make_shifted_4dstem()
+    w = Show4DSTEM(data, verbose=False)
+    for mode in ["com_x", "com_y", "com_mag", "icom", "dcom", "curl"]:
+        w.roi_mode = mode
+        assert len(w.virtual_image_bytes) > 0, f"{mode} produced empty VI"
+        vi = np.frombuffer(w.virtual_image_bytes, dtype=np.float32)
+        assert vi.size == 8 * 8, f"{mode} wrong size"
+
+
+def test_show4dstem_com_magnitude_nonnegative():
+    """COM magnitude is always >= 0."""
+    data = _make_shifted_4dstem()
+    w = Show4DSTEM(data, verbose=False)
+    w.roi_mode = "com_mag"
+    vi = np.frombuffer(w.virtual_image_bytes, dtype=np.float32)
+    assert vi.min() >= 0
+
+
+def test_show4dstem_com_nonzero_for_shifted():
+    """COM magnitude should be nonzero when BF disk shifts across scan."""
+    # Use quadratic shift so plane-fit subtraction doesn't remove all signal
+    scan_rows, scan_cols, det_rows, det_cols = 16, 16, 32, 32
+    data = np.zeros((scan_rows, scan_cols, det_rows, det_cols), dtype=np.float32)
+    cr, cc = det_rows // 2, det_cols // 2
+    rr, ccc = np.mgrid[:det_rows, :det_cols]
+    for i in range(scan_rows):
+        for j in range(scan_cols):
+            # Quadratic shift: survives plane-fit background subtraction
+            sr = 2.0 * ((i / (scan_rows - 1)) - 0.5) ** 2
+            sc = 1.5 * ((j / (scan_cols - 1)) - 0.5) ** 2
+            disk = ((rr - (cr + sr)) ** 2 + (ccc - (cc + sc)) ** 2 < 4**2).astype(np.float32)
+            data[i, j] = disk
+    w = Show4DSTEM(data, verbose=False)
+    w.roi_mode = "com_mag"
+    vi = np.frombuffer(w.virtual_image_bytes, dtype=np.float32)
+    assert np.abs(vi).max() > 0.001
+
+
+def test_show4dstem_icom_recovers_structure():
+    """iCOM should produce a smooth potential map from 2D COM field."""
+    # Need shifts in both row AND col for the Fourier Poisson solver to work
+    scan_rows, scan_cols, det_rows, det_cols = 16, 16, 32, 32
+    data = np.zeros((scan_rows, scan_cols, det_rows, det_cols), dtype=np.float32)
+    cr, cc = det_rows // 2, det_cols // 2
+    rr, ccc = np.mgrid[:det_rows, :det_cols]
+    for i in range(scan_rows):
+        for j in range(scan_cols):
+            sr = 1.5 * (i / max(scan_rows - 1, 1))
+            sc = 1.0 * (j / max(scan_cols - 1, 1))
+            disk = ((rr - (cr + sr)) ** 2 + (ccc - (cc + sc)) ** 2 < 4**2).astype(np.float32)
+            data[i, j] = disk
+    w = Show4DSTEM(data, verbose=False)
+    w.roi_mode = "icom"
+    vi = np.frombuffer(w.virtual_image_bytes, dtype=np.float32).reshape(scan_rows, scan_cols)
+    assert vi.std() > 0, "iCOM should have spatial variation"
+
+
+def test_show4dstem_com_state_roundtrip():
+    """COM mode survives state_dict roundtrip."""
+    data = _make_shifted_4dstem()
+    w = Show4DSTEM(data, verbose=False)
+    w.roi_mode = "com_mag"
+    sd = w.state_dict()
+    assert sd["roi_mode"] == "com_mag"
+
+
+def test_show4dstem_com_cache_invalidation():
+    """COM cache is populated on first use and cleared by auto_detect_center."""
+    data = _make_shifted_4dstem()
+    w = Show4DSTEM(data, verbose=False)
+    # Initially no COM cache
+    assert w._cached_com_row is None
+    # Trigger COM computation
+    w.roi_mode = "com_x"
+    assert len(w.virtual_image_bytes) > 0
+    # Cache should now be populated
+    assert w._cached_com_row is not None
+    assert w._cached_com_col is not None
+    # auto_detect_center clears the cache
+    w.auto_detect_center()
+    assert w._cached_com_row is None
+    assert w._cached_com_col is None
+    # Re-trigger COM: should recompute (not use stale cache)
+    w.roi_mode = "point"
+    w.roi_mode = "com_x"
+    assert w._cached_com_row is not None
+
+
 # ── dp_vmin/dp_vmax + vi_vmin/vi_vmax tests ─────────────────────────────────
 
 

--- a/tests/test_widget_showcomplex.py
+++ b/tests/test_widget_showcomplex.py
@@ -993,12 +993,10 @@ def test_showcomplex_vmin_vmax_summary(capsys):
     assert "vmax=100" in out
 
 
-def test_showcomplex_vmin_vmax_phase_mode_ignores():
+def test_showcomplex_vmin_vmax_phase_mode_ignores(tmp_path):
     """Phase mode always uses [-pi, pi], ignoring vmin/vmax."""
     data = (np.random.rand(16, 16) + 1j * np.random.rand(16, 16)).astype(np.complex64)
     w = ShowComplex2D(data, vmin=0, vmax=100, display_mode="phase")
     # save_image in phase mode should still work (uses [-pi, pi])
-    import tempfile
-    with tempfile.NamedTemporaryFile(suffix=".png") as f:
-        path = w.save_image(f.name, display_mode="phase")
-        assert path.exists()
+    path = w.save_image(str(tmp_path / "phase.png"), display_mode="phase")
+    assert path.exists()


### PR DESCRIPTION
- Add 6 center-of-mass virtual imaging modes that compute beam deflection maps from 4D-STEM dat:
  - com-x/com-y
  - com magnitude
  - iCOM - integrated COM via Fourier-space Poisson solver, recovers projected electrostatic potential
  - dCOM - divergence of COM field
  - curl (EM)
- Corresponding tests
- Rewrite show4dstem all_features notebook data generator to simulate SrTiO3 perovskite crystal (atomic potential gradient & BF disk shift, Bragg spots, thickness modulation) to achieve clearer/more obvious visualisations
<img width="844" height="524" alt="Screenshot 2026-04-22 at 2 11 08 PM" src="https://github.com/user-attachments/assets/74c3fc93-b4b9-4159-8aec-79f613f17d02" />
